### PR TITLE
Use utcnow instead to avoid timezone issue

### DIFF
--- a/mb8600/modem.py
+++ b/mb8600/modem.py
@@ -129,7 +129,7 @@ class MB8600:
                     "ChannelID": value["ChannelID"],
 
                 },
-                "time": datetime.now().isoformat(),
+                "time": datetime.utcnow().isoformat(),
                 "fields": {
                     field_key: value[field_key] for field_key in value if field_key not in tags
                 }
@@ -143,7 +143,7 @@ class MB8600:
                     "Channel": value["Channel"],
                     "ChannelID": value["ChannelID"],
                 },
-                "time": datetime.now().isoformat(),
+                "time": datetime.utcnow().isoformat(),
                 "fields": {
                     field_key: value[field_key] for field_key in value if field_key not in tags
                 }
@@ -157,7 +157,7 @@ class MB8600:
                 "tags": {
                     "host": self.host,
                 },
-                "time": datetime.now().isoformat(),
+                "time": datetime.utcnow().isoformat(),
                 "fields": {
                     **data['GetMotoStatusSoftwareResponse'],
                     **data['GetHomeConnectionResponse'],
@@ -178,7 +178,7 @@ class MB8600:
                 "tags": {
                     "host": self.host,
                 },
-                "time": datetime.now().isoformat(),
+                "time": datetime.utcnow().isoformat(),
                 "fields": {
                     "uptime": timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds).total_seconds()
                 }


### PR DESCRIPTION
By default influxdb takes in the timestamp as `utc`, but the machine running this python script might be on different timezone.  

This works (on my machine as always) after the change.